### PR TITLE
Mise à jour globale de l'outil

### DIFF
--- a/SECUREBOOT/data/install-kernel-autosign-gui.sh
+++ b/SECUREBOOT/data/install-kernel-autosign-gui.sh
@@ -8,12 +8,12 @@ if [[ $EUID -ne 0 ]]; then
 	exit 1
 fi
 
-cp $srcdir/SECUREBOOT/data/src/zz-signing /etc/kernel/postinst.d
+cp "$srcdir"/SECUREBOOT/data/src/zz-signing /etc/kernel/postinst.d
 chown root:root /etc/kernel/postinst.d/zz-signing
 chmod u+rx /etc/kernel/postinst.d/zz-signing
 
 echo "
-Signatures automatiques des kernels installé
+Signatures automatiques des kernels installés
 "
 
 # Uncomment to use with ubuntu mainline

--- a/SECUREBOOT/data/install-kernel-autosign.sh
+++ b/SECUREBOOT/data/install-kernel-autosign.sh
@@ -8,12 +8,12 @@ if [[ $EUID -ne 0 ]]; then
 	exit 1
 fi
 
-cp $srcdir/SECUREBOOT/data/src/zz-signing /etc/kernel/postinst.d
+cp "$srcdir"/SECUREBOOT/data/src/zz-signing /etc/kernel/postinst.d
 chown root:root /etc/kernel/postinst.d/zz-signing
 chmod u+rx /etc/kernel/postinst.d/zz-signing
 
 echo "
-Signatures automatiques des kernels installé
+Signatures automatiques des kernels installés
 "
 
 # Uncomment to use with ubuntu mainline

--- a/SECUREBOOT/data/secureboot.sh
+++ b/SECUREBOOT/data/secureboot.sh
@@ -57,22 +57,19 @@ REBOOTEZ LA MACHINE MAINTENANT POUR ENROLL LA CLE
 
 function sign_helper() {
 
-sign1='mok_signing_key="/var/lib/shim-signed/mok/MOK.priv"'
-sign2='mok_certificate="/var/lib/shim-signed/mok/MOK.der"'
-sign3='sign_tool="/etc/dkms/sign_helper.sh"'
-sign4='sign_file="/opt/signtool/sign-file"'
-sign5='autoinstall_all_kernels="true"'
-sign6='modprobe_on_install="true"'
+cat <<EOL >> /etc/dkms/framework.conf
+mok_signing_key="/var/lib/shim-signed/mok/MOK.priv"
+mok_certificate="/var/lib/shim-signed/mok/MOK.der"
+sign_tool="/etc/dkms/sign_helper.sh"
+sign_file="/opt/signtool/sign-file"
+autoinstall_all_kernels="true"
+modprobe_on_install="true"
+EOL
 
-echo $sign1 > /etc/dkms/framework.conf
-echo $sign2 >> /etc/dkms/framework.conf
-echo $sign3 >> /etc/dkms/framework.conf
-echo $sign4 >> /etc/dkms/framework.conf
-echo $sign5 >> /etc/dkms/framework.conf
-echo $sign6 >> /etc/dkms/framework.conf
-
-sign_helper='/opt/signtool/sign-file sha256 /var/lib/shim-signed/mok/MOK.priv /var/lib/shim-signed/mok/MOK.der "$2"'
-echo $sign_helper > /etc/dkms/sign_helper.sh
+cat <<EOL > /etc/dkms/sign_helper.sh
+#!/bin/sh
+opt/signtool/sign-file sha256 /var/lib/shim-signed/mok/MOK.priv /var/lib/shim-signed/mok/MOK.der "\$2"
+EOL
 chmod +x /etc/dkms/sign_helper.sh
 }
 
@@ -87,7 +84,7 @@ MODULES_DIR=/lib/modules/$VERSION
 KBUILD_DIR=/usr/lib/linux-kbuild-$SHORT_VERSION
 
 sbsign --key /var/lib/shim-signed/mok/MOK.priv --cert /var/lib/shim-signed/mok/MOK.pem "/boot/vmlinuz-$VERSION" --output "/boot/vmlinuz-$VERSION.tmp"
-mv /boot/vmlinuz-$VERSION.tmp /boot/vmlinuz-$VERSION
+mv /boot/vmlinuz-"$VERSION".tmp /boot/vmlinuz-"$VERSION"
 }
 
 function sign_modules() {

--- a/SECUREBOOT/install-sb-gui.sh
+++ b/SECUREBOOT/install-sb-gui.sh
@@ -13,36 +13,36 @@ Configuration du système SECUREBOOT
 
 Installation des dépendances...
 " ; sleep 1
-apt install -f dkms patch > /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -f dkms patch > /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 kernel_ver=$(uname -r)
 srcdir=$(pwd)
 export srcdir
-chmod +x $srcdir/SECUREBOOT/data/*.sh
-chmod +x $srcdir/SECUREBOOT/data/src/zz-signing
+chmod +x "$srcdir"/SECUREBOOT/data/*.sh
+chmod +x "$srcdir"/SECUREBOOT/data/src/zz-signing
 
 echo "
 installation de sign-file pour les Kernels Customs...
 " ; sleep 1
 mkdir -p /opt/signtool/
-cp /lib/modules/$kernel_ver/build/scripts/sign-file /opt/signtool
+cp /lib/modules/"$kernel_ver"/build/scripts/sign-file /opt/signtool
 
 echo "
 Patch de dkms pour les kernels Customs, blocage des mises à jour du paquet
 " ; sleep 1
-# patch -i $srcdir/data/dkms.patch /usr/sbin/dkms
+# patch -i "$srcdir"/data/dkms.patch /usr/sbin/dkms
 # En cas de changement de version de dkms
-cp $srcdir/SECUREBOOT/data/src/dkms.patched /usr/sbin/dkms
+cp "$srcdir"/SECUREBOOT/data/src/dkms.patched /usr/sbin/dkms
 chmod +x /usr/sbin/dkms
 apt-mark hold dkms
 
 echo "
 Installation...
 " ; sleep 1
-cd $srcdir
+cd "$srcdir"
 
-source $srcdir/SECUREBOOT/data/secureboot.sh
-source $srcdir/SECUREBOOT/data/install-kernel-autosign-gui.sh
+source "$srcdir"/SECUREBOOT/data/secureboot.sh
+source "$srcdir"/SECUREBOOT/data/install-kernel-autosign-gui.sh
 
 echo "
 Job done

--- a/SECUREBOOT/install-sb.sh
+++ b/SECUREBOOT/install-sb.sh
@@ -13,36 +13,36 @@ Configuration du système SECUREBOOT
 
 Installation des dépendances...
 " ; sleep 1
-apt install -f dkms patch > /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -f dkms patch > /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 kernel_ver=$(uname -r)
 srcdir=$(pwd)
 export srcdir
-chmod +x $srcdir/SECUREBOOT/data/*.sh
-chmod +x $srcdir/SECUREBOOT/data/src/zz-signing
+chmod +x "$srcdir"/SECUREBOOT/data/*.sh
+chmod +x "$srcdir"/SECUREBOOT/data/src/zz-signing
 
 echo "
 installation de sign-file pour les Kernels Customs...
 " ; sleep 1
 mkdir -p /opt/signtool/
-cp /lib/modules/$kernel_ver/build/scripts/sign-file /opt/signtool
+cp /lib/modules/"$kernel_ver"/build/scripts/sign-file /opt/signtool
 
 echo "
 Patch de dkms pour les kernels Customs, blocage des mises à jour du paquet
 " ; sleep 1
-# patch -i $srcdir/data/dkms.patch /usr/sbin/dkms
+# patch -i "$srcdir"/data/dkms.patch /usr/sbin/dkms
 # En cas de changement de version de dkms
-cp $srcdir/SECUREBOOT/data/src/dkms.patched /usr/sbin/dkms
+cp "$srcdir"/SECUREBOOT/data/src/dkms.patched /usr/sbin/dkms
 chmod +x /usr/sbin/dkms
 apt-mark hold dkms
 
 echo "
 Installation...
 " ; sleep 1
-cd $srcdir
+cd "$srcdir"
 
-source $srcdir/SECUREBOOT/data/secureboot.sh
-source $srcdir/SECUREBOOT/data/install-kernel-autosign.sh
+source "$srcdir"/SECUREBOOT/data/secureboot.sh
+source "$srcdir"/SECUREBOOT/data/install-kernel-autosign.sh
 
 echo "
 Job done

--- a/data/amd-vulkan.sh
+++ b/data/amd-vulkan.sh
@@ -14,11 +14,11 @@ echo "Installation de Vulkan AMD/Intel
 
 echo "Vérification des dépôts additionnels"; sleep 1
 dpkg --add-architecture i386
-apt-add-repository -y contrib > /var/log/$LOGNAME.auto-update.txt 2>&1
-apt-add-repository -y non-free >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt-add-repository -y contrib > /var/log/"$LOGNAME".auto-update.txt 2>&1
+apt-add-repository -y non-free >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Installation..."
-apt install -y libgl1-mesa-dri libgl1-mesa-dri:i386 mesa-vulkan-drivers mesa-vulkan-drivers:i386 vulkan-tools >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y libgl1-mesa-dri libgl1-mesa-dri:i386 mesa-vulkan-drivers mesa-vulkan-drivers:i386 vulkan-tools >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "
 Job done

--- a/data/install-sid.sh
+++ b/data/install-sid.sh
@@ -9,7 +9,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 clear
-echo "Installation des repos Sid en pin 10 pour Debian Testing
+echo "Installation des dépôts Sid en pin 10 pour Debian Testing
 " ; sleep 2
 
 if [ ! -x /etc/apt/sources.list.d/sid.list ]
@@ -28,8 +28,8 @@ else
 	echo "Le fichier /etc/apt/preferences.d/sid existe déjà !!"
 fi
 
-echo "Rafraichissemnt des dépôts"; sleep 1
-apt update > /var/log/$LOGNAME.auto-update.txt 2>&1
+echo "Rafraîchissemnt des dépôts"; sleep 1
+apt update > /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "
 Job done

--- a/data/lutris-latest.sh
+++ b/data/lutris-latest.sh
@@ -8,7 +8,7 @@ if [[ $EUID -ne 0 ]]; then
 	exit 1
 fi
 
-echo "Job start : Installing Lutris Latest
+echo "Job start : Installation de la dernière version Lutris
 " ; sleep 2
 
 echo "Ajout du dépôt lutris.list"
@@ -17,12 +17,12 @@ echo "deb [signed-by=/etc/apt/keyrings/lutris.gpg] https://download.opensuse.org
 echo "Installation de la clé GPG"
 wget -q -O- https://download.opensuse.org/repositories/home:/strycore/Debian_12/Release.key | gpg --dearmor | sudo tee /etc/apt/keyrings/lutris.gpg > /dev/null
 
-echo "Rafraichissement des dépôts"
-apt update > /var/log/$LOGNAME.auto-update.txt 2>&1
+echo "Rafraîchissement des dépôts"
+apt update > /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Installation de Lutris"
-apt install -y python3-gi-cairo >> /var/log/$LOGNAME.auto-update.txt 2>&1
-apt install -y lutris >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y python3-gi-cairo >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+apt install -y lutris >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "
 Job done

--- a/data/mesa-kisak-fresh.sh
+++ b/data/mesa-kisak-fresh.sh
@@ -17,10 +17,10 @@ apt-key adv --keyserver keyserver.ubuntu.com --recv-keys F63F0F2B90935439 && \
 mv /etc/apt/trusted.gpg /etc/apt/trusted.gpg.d/mesa-kisak-fresh.gpg
 
 echo "Rafraichissement des dépôts"; sleep 1
-apt-get update > /var/log/$LOGNAME.auto-update.txt 2>&1
+apt-get update > /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Mise a niveau du système"; sleep 1
-apt-get full-upgrade -y >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt-get full-upgrade -y >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "
 Job done

--- a/data/nvidia-rollback.sh
+++ b/data/nvidia-rollback.sh
@@ -9,11 +9,11 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 clear 
-echo "Job start : Uninstalling Nvidia Drivers
+echo "Job start : Désinstallation des drivers Nvidia
 "; sleep 2
 
-apt autopurge -y cuda-keyring nvidia-cuda-toolkit nvidia-cuda-dev nvidia-cuda-mps > /var/log/$LOGNAME.auto-update.txt 2>&1
-apt autopurge -y nvidia-driver vulkan-tools firmware-misc-nonfree nvidia-settings libglvnd-dev libvulkan*:i386 nvidia-driver-libs:i386 nvidia-cuda-toolkit nvidia-cuda-dev nvidia-cuda-mps >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt autopurge -y cuda-keyring nvidia-cuda-toolkit nvidia-cuda-dev nvidia-cuda-mps > /var/log/"$LOGNAME".auto-update.txt 2>&1
+apt autopurge -y nvidia-driver vulkan-tools firmware-misc-nonfree nvidia-settings libglvnd-dev libvulkan*:i386 nvidia-driver-libs:i386 nvidia-cuda-toolkit nvidia-cuda-dev nvidia-cuda-mps >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Veuillez REBOOT la machine !!"
 

--- a/data/nvidia-stable.sh
+++ b/data/nvidia-stable.sh
@@ -15,46 +15,46 @@ echo "Installation des Nvidia Drivers Stable + Cuda
 
 echo "*** BUG DEBIAN 12 LIVE ISOS :
 
-Le paquet raspi-firmware installé par défaut dans ces isos est cassée, empêchant la mise à jour de l'initramfs.
+Le paquet raspi-firmware installé par défaut dans ces isos est cassé, empêchant la mise à jour de l'initramfs.
 Par sécurité, il sera désinstallé et nettoyé. Si vous en avez besoin, considérez le bug et prenez un paquet plus récent en provenance de Sid sur pkgs.org ***
 
-NOTE : Un clean de vulkan/mesa/nvidia sera effectué pour éviter tout conflit. En cas de necessité, vous devrez reinstaller mesa-vulkan-drivers mesa-vulkan-drivers:i386 (INTEL/AMD).
+NOTE : Un nettoyage de vulkan/mesa/nvidia sera effectué pour éviter tout conflit. En cas de nécessité, vous devrez réinstaller mesa-vulkan-drivers mesa-vulkan-drivers:i386 (INTEL/AMD).
 
 Veuillez patienter...
 "; sleep 5
 
-apt autopurge -y raspi-firmware > /var/log/$LOGNAME.auto-update.txt 2>&1
+apt autopurge -y raspi-firmware > /var/log/"$LOGNAME".auto-update.txt 2>&1
 rm /etc/initramfs/post-update.d/z50-raspi-firmware
 
 echo "
 Préparation des dépendances :
 "; sleep 2
 
-dpkg --add-architecture i386 >> /var/log/$LOGNAME.auto-update.txt 2>&1
-add-apt-repository -y contrib >> /var/log/$LOGNAME.auto-update.txt 2>&1
-add-apt-repository -y non-free >> /var/log/$LOGNAME.auto-update.txt 2>&1
+dpkg --add-architecture i386 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+add-apt-repository -y contrib >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+add-apt-repository -y non-free >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
-apt install -y linux-headers-amd64 build-essential dkms libglvnd-dev firmware-misc-nonfree pkg-config wget >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y linux-headers-amd64 build-essential dkms libglvnd-dev firmware-misc-nonfree pkg-config wget >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "
 Nettoyage du système :
 "; sleep 2
 
-apt autopurge -y nvidia* nvidia*:i386 mesa-vulkan-drivers mesa-vulkan-drivers:i386 >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt autopurge -y nvidia* nvidia*:i386 mesa-vulkan-drivers mesa-vulkan-drivers:i386 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "
 Installation du driver et de Vulkan + Lib32 :
 "; sleep 2
 
 mkdir -p /var/run/nvpd/
-apt install -y nvidia-driver vulkan-tools nvidia-settings >> /var/log/$LOGNAME.auto-update.txt 2>&1
-apt install -y vulkan-tools:i386 nvidia-driver-libs:i386 >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y nvidia-driver vulkan-tools nvidia-settings >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+apt install -y vulkan-tools:i386 nvidia-driver-libs:i386 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "
 Installation de Cuda :
 "; sleep 2
 
-apt install -y nvidia-cuda-toolkit nvidia-cuda-dev >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y nvidia-cuda-toolkit nvidia-cuda-dev >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Veuillez REBOOT la machine !!"
 

--- a/data/rocm.sh
+++ b/data/rocm.sh
@@ -9,16 +9,15 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 clear
-echo "
-Installation de ROCM HIP et OPENCL Runtimes
+echo "Installation de ROCM HIP et OPENCL Runtimes
 " ; sleep 2
 
 localdir=$(pwd)
 echo "Copie de la clé du dépot AMD"
-cp $localdir/data/keyring/rocm-keyring.gpg /etc/apt/trusted.gpg.d/
+cp "$localdir"/data/keyring/rocm-keyring.gpg /etc/apt/trusted.gpg.d/
 sleep 1
 
-echo "Ajout des dépots rocm et amdgpu"
+echo "Ajout des dépôts rocm et amdgpu"
 echo "deb https://repo.radeon.com/amdgpu/latest/ubuntu jammy main" > /etc/apt/sources.list.d/amdgpu.list
 echo "deb [arch=amd64] https://repo.radeon.com/rocm/apt/latest jammy main" > /etc/apt/sources.list.d/rocm.list
 echo "Package: *
@@ -26,17 +25,17 @@ Pin: release o=repo.radeon.com
 Pin-Priority: 600" > /etc/apt/preferences.d/repo-radeon-pin-600
 sleep 1
 
-echo "Rafraichissement des dépôts"
-apt update > /var/log/$LOGNAME.auto-update.txt 2>&1
+echo "Rafraîchissement des dépôts"
+apt update > /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Installation de OPENCL"
-apt install -y rocm-opencl-runtime >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y rocm-opencl-runtime >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Installation de HIP. Cela peut être TRES long ! (2Go)"
 apt install -y rocm-hip-runtime
 
 echo "Ajout de l'utilisateur aux groupes Video et Render"
-usermod -aG video,render $(who | grep tty | cut -d " " -f 1)
+usermod -aG video,render "$(who | grep tty | cut -d " " -f 1)"
 sleep 1
 
 echo "

--- a/data/steam.sh
+++ b/data/steam.sh
@@ -15,14 +15,14 @@ echo "Installation de Steam
 echo "Préparation des dépendances :
 "; sleep 2
 
-dpkg --add-architecture i386 > /var/log/$LOGNAME.auto-update.txt 2>&1
-add-apt-repository -y contrib >> /var/log/$LOGNAME.auto-update.txt 2>&1
-add-apt-repository -y non-free >> /var/log/$LOGNAME.auto-update.txt 2>&1
+dpkg --add-architecture i386 > /var/log/"$LOGNAME".auto-update.txt 2>&1
+add-apt-repository -y contrib >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+add-apt-repository -y non-free >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Installation... Veuillez patienter
 "; sleep 2
 
-apt install -y steam-installer >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y steam-installer >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Vous devrez terminer l'installation en exécutant steam-installer dans le menu des jeux
 "; sleep 2

--- a/data/wine-staging.sh
+++ b/data/wine-staging.sh
@@ -18,11 +18,11 @@ echo "Installation du dépôt"
 wget -O /etc/apt/keyrings/winehq-archive.key https://dl.winehq.org/wine-builds/winehq.key
 wget -NP /etc/apt/sources.list.d/ https://dl.winehq.org/wine-builds/debian/dists/bookworm/winehq-bookworm.sources
 
-echo "Rafraichissement des dépôts"
-apt update > /var/log/$LOGNAME.auto-update.txt 2>&1
+echo "Rafraîchissement des dépôts"
+apt update > /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Installation..."
-apt install -y --install-recommends winehq-staging >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y --install-recommends winehq-staging >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "
 Job done

--- a/extra/backports.sh
+++ b/extra/backports.sh
@@ -9,7 +9,7 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 clear
-echo "Configuration des Backports
+echo "Configuration des dépôts Backports
 "; sleep 2
 
 if [ ! -x /etc/apt/sources.list.d/sid.list ]
@@ -19,8 +19,8 @@ else
 	echo "Le fichier /etc/apt/sources.list.d/backports.list existe déjà !!"
 fi
 
-echo "Rafraichissement des dépôts"
-sudo apt update > /var/log/$LOGNAME.auto-update.txt 2>&1
+echo "Rafraîchissement des dépôts"
+apt update > /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "
 Job done

--- a/extra/nvidia-cuda.sh
+++ b/extra/nvidia-cuda.sh
@@ -12,30 +12,30 @@ clear
 echo "Installation des drivers Nvidia Cuda LTS (dépôt Nvidia)
 "; sleep 2
 
-echo "*** BUG DEBIAN 12 LIVE ISOS :
+echo "*** BUG DEBIAN 12 LIVE ISOs :
 
-Le paquet raspi-firmware installé par défaut dans ces isos est cassée, empêchant la mise à jour de l'initramfs.
-Par sécurité, il sera désinstallé et nettoyé. Si vous en avez besoin, considérez le bug et prenez un paquet plus récent en provenance de Sid sur pkgs.org ***
+Le paquet raspi-firmware installé par défaut dans ces ISOs est cassé, empêchant la mise à jour de l'initramfs.
+Par sécurité, il sera désinstallé et nettoyé. Si vous en avez besoin, considérez le bug et prenez un paquet plus récent en provenance de Sid sur pkgs.org. ***
 
-NOTE : Un clean de vulkan/mesa/nvidia sera effectué pour éviter tout conflit. En cas de necessité, vous devrez reinstaller mesa-vulkan-drivers mesa-vulkan-drivers:i386 (INTEL/AMD).
+NOTE : Un nettoyage de vulkan/mesa/nvidia sera effectué pour éviter tout conflit. En cas de nécessité, vous devrez réinstaller mesa-vulkan-drivers mesa-vulkan-drivers:i386 (INTEL/AMD).
 "; sleep 5
 
-apt autopurge -y raspi-firmware > /var/log/$LOGNAME.auto-update.txt 2>&1
+apt autopurge -y raspi-firmware > /var/log/"$LOGNAME".auto-update.txt 2>&1
 rm /etc/initramfs/post-update.d/z50-raspi-firmware
 
 echo "Préparation des dépendances :
 "; sleep 2
 
-dpkg --add-architecture i386 >> /var/log/$LOGNAME.auto-update.txt 2>&1
-add-apt-repository -y contrib >> /var/log/$LOGNAME.auto-update.txt 2>&1
-add-apt-repository -y non-free >> /var/log/$LOGNAME.auto-update.txt 2>&1
+dpkg --add-architecture i386 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+add-apt-repository -y contrib >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+add-apt-repository -y non-free >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
-apt install -y linux-headers-amd64 build-essential dkms firmware-misc-nonfree pkg-config wget >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y linux-headers-amd64 build-essential dkms firmware-misc-nonfree pkg-config wget >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Nettoyage du système :
 "; sleep 2
 
-apt autopurge -y nvidia-driver nvidia-settings nvidia-driver-libs:i386 cuda nvidia-gds mesa-vulkan-drivers mesa-vulkan-drivers:i386 >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt autopurge -y nvidia-driver nvidia-settings nvidia-driver-libs:i386 cuda nvidia-gds mesa-vulkan-drivers mesa-vulkan-drivers:i386 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
  
 
 echo "
@@ -49,13 +49,14 @@ wget https://developer.download.nvidia.com/compute/cuda/repos/debian11/x86_64/cu
 dpkg -i cuda-keyring_1.1-1_all.deb 
 rm cuda-keyring_1.1-1_all.deb
 
-echo "Rafraichissement des dépôts"
-apt update >> /var/log/$LOGNAME.auto-update.txt 2>&1
+echo "Rafraîchissement des dépôts"
+apt update >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Mise à niveau du système"
-apt full-upgrade -y >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt full-upgrade -y >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
-echo "Installation... (LONG !)
+echo "Installation... (LONG !)"
+
 mkdir -p /var/run/nvpd/
 apt install -y cuda nvidia-driver nvidia-settings vulkan-tools libglvnd-dev nvidia-driver-libs:i386
 # apt install nvidia-gds

--- a/extra/nvidia-experimental.sh
+++ b/extra/nvidia-experimental.sh
@@ -9,49 +9,49 @@ if [[ $EUID -ne 0 ]]; then
 fi
 
 clear
-echo "Job start : Installing Nvidia Experimental Drivers
+echo "Installation des drivers Nvidia Experimental
 "; sleep 2
 
 echo "*** BUG DEBIAN 12 LIVE ISOS :
 
-Le paquet raspi-firmware installé par défaut dans ces isos est cassée, empêchant la mise à jour de l'initramfs.
+Le paquet raspi-firmware installé par défaut dans ces ISOs est cassé, empêchant la mise à jour de l'initramfs.
 Par sécurité, il sera désinstallé et nettoyé. Si vous en avez besoin, considérez le bug et prenez un paquet plus récent en provenance de Sid sur pkgs.org ***
 
-NOTE : Un clean de vulkan/mesa/nvidia sera effectué pour éviter tout conflit. En cas de necessité, vous devrez reinstaller mesa-vulkan-drivers mesa-vulkan-drivers:i386 (INTEL/AMD).
+NOTE : Un nettoyage de vulkan/mesa/nvidia sera effectué pour éviter tout conflit. En cas de nécessité, vous devrez réinstaller mesa-vulkan-drivers mesa-vulkan-drivers:i386 (INTEL/AMD).
 
 "; sleep 5
 
-apt autopurge -y raspi-firmware > /var/log/$LOGNAME.auto-update.txt 2>&1
+apt autopurge -y raspi-firmware > /var/log/"$LOGNAME".auto-update.txt 2>&1
 rm /etc/initramfs/post-update.d/z50-raspi-firmware
 
 echo "
 Préparation des dépendances 
 "
 sleep 2
-dpkg --add-architecture i386 >> /var/log/$LOGNAME.auto-update.txt 2>&1
-add-apt-repository -y contrib >> /var/log/$LOGNAME.auto-update.txt 2>&1
-add-apt-repository -y non-free >> /var/log/$LOGNAME.auto-update.txt 2>&1
+dpkg --add-architecture i386 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+add-apt-repository -y contrib >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+add-apt-repository -y non-free >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
-apt install -y linux-headers-amd64 build-essential dkms libglvnd-dev firmware-misc-nonfree pkg-config wget >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y linux-headers-amd64 build-essential dkms libglvnd-dev firmware-misc-nonfree pkg-config wget >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Nettoyage du système 
 "; sleep 2
 
-apt autopurge -y nvidia-driver nvidia-settings nvidia-driver-libs:i386 cuda nvidia-gds mesa-vulkan-drivers mesa-vulkan-drivers:i386 nvidia-* nvidia*:i386 >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt autopurge -y nvidia-driver nvidia-settings nvidia-driver-libs:i386 cuda nvidia-gds mesa-vulkan-drivers mesa-vulkan-drivers:i386 nvidia-* nvidia*:i386 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 if [ ! -x /etc/apt/sources.list.d/experimental.list ]
 then
     echo "deb http://deb.debian.org/debian experimental non-free-firmware contrib non-free main" > /etc/apt/sources.list.d/experimental.list
 fi
 
-dpkg --add-architecture i386 >> /var/log/$LOGNAME.auto-update.txt 2>&1
-apt update >> /var/log/$LOGNAME.auto-update.txt 2>&1
+dpkg --add-architecture i386 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+apt update >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Installation du driver et de Vulkan + Lib32 (LONG !)
 "; sleep 2
 
 export DEBIAN_FRONTEND=noninteractive
-apt update >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt update >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 apt-mark unhold dkms
 mkdir -p /var/run/nvpd/
 apt install -y -t sid dkms
@@ -65,7 +65,7 @@ apt install -y -t experimental nvidia-cuda-toolkit
 # nvidia-cuda-dev
 # nvidia-cuda-mps
 
-echo "SI VOUS UTILISEZ SECUREBOOT, VEUILLEZ RELANCER LA PRECEDURE !
+echo "SI VOUS UTILISEZ SECUREBOOT, VEUILLEZ RELANCER LA PROCEDURE !
 
 Veuillez REBOOT la machine !!
 "; sleep 2

--- a/extra/nvidia-testing-on-stable.sh
+++ b/extra/nvidia-testing-on-stable.sh
@@ -14,29 +14,29 @@ echo "Installation des drivers Debian Nvidia Testing Driver + Cuda
 
 echo "*** BUG DEBIAN 12 LIVE ISOS :
 
-Le paquet raspi-firmware installé par défaut dans ces isos est cassée, empêchant la mise à jour de l'initramfs.
+Le paquet raspi-firmware installé par défaut dans ces isos est cassé, empêchant la mise à jour de l'initramfs.
 Par sécurité, il sera désinstallé et nettoyé. Si vous en avez besoin, considérez le bug et prenez un paquet plus récent en provenance de Sid sur pkgs.org ***
 
-NOTE : Un clean de vulkan/mesa/nvidia sera effectué pour éviter tout conflit. En cas de necessité, vous devrez reinstaller mesa-vulkan-drivers mesa-vulkan-drivers:i386 (INTEL/AMD).
+NOTE : Un clean de vulkan/mesa/nvidia sera effectué pour éviter tout conflit. En cas de nécessité, vous devrez réinstaller mesa-vulkan-drivers mesa-vulkan-drivers:i386 (INTEL/AMD).
 
 "; sleep 5
 
-apt autopurge -y raspi-firmware > /var/log/$LOGNAME.auto-update.txt 2>&1
+apt autopurge -y raspi-firmware > /var/log/"$LOGNAME".auto-update.txt 2>&1
 rm /etc/initramfs/post-update.d/z50-raspi-firmware
 
 echo "Préparation des dépendances 
 "; sleep 2
 
-dpkg --add-architecture i386 >> /var/log/$LOGNAME.auto-update.txt 2>&1
-add-apt-repository -y contrib >> /var/log/$LOGNAME.auto-update.txt 2>&1
-add-apt-repository -y non-free >> /var/log/$LOGNAME.auto-update.txt 2>&1
+dpkg --add-architecture i386 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+add-apt-repository -y contrib >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+add-apt-repository -y non-free >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
-apt install -y linux-headers-amd64 build-essential dkms libglvnd-dev firmware-misc-nonfree pkg-config wget >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y linux-headers-amd64 build-essential dkms libglvnd-dev firmware-misc-nonfree pkg-config wget >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Nettoyage du système 
 "; sleep 2
 
-apt autopurge -y nvidia-driver nvidia-settings nvidia-driver-libs:i386 cuda nvidia-gds mesa-vulkan-drivers mesa-vulkan-drivers:i386 nvidia-* nvidia*:i386 >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt autopurge -y nvidia-driver nvidia-settings nvidia-driver-libs:i386 cuda nvidia-gds mesa-vulkan-drivers mesa-vulkan-drivers:i386 nvidia-* nvidia*:i386 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Ajout du dépôt testing 
 "; sleep 2
@@ -60,8 +60,8 @@ fi
 echo "Rafraichissement des dépôts
 "; sleep 2
 
-dpkg --add-architecture i386 >> /var/log/$LOGNAME.auto-update.txt 2>&1
-apt update >> /var/log/$LOGNAME.auto-update.txt 2>&1
+dpkg --add-architecture i386 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+apt update >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Installation du driver et de Vulkan + Lib32 (LONG !)
 "; sleep 2
@@ -69,13 +69,13 @@ echo "Installation du driver et de Vulkan + Lib32 (LONG !)
 export DEBIAN_FRONTEND=noninteractive
 apt-mark unhold dkms
 mkdir -p /var/run/nvpd/
-apt install -y -t testing dkms nvidia-driver vulkan-tools libglvnd-dev firmware-misc-nonfree linux-headers-amd64 linux-image-amd64 >> /var/log/$LOGNAME.auto-update.txt 2>&1
-apt install -y -t testing nvidia-driver-libs:i386 >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y -t testing dkms nvidia-driver vulkan-tools libglvnd-dev firmware-misc-nonfree linux-headers-amd64 linux-image-amd64 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
+apt install -y -t testing nvidia-driver-libs:i386 >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Installation de Cuda (LONG !)
 "; sleep 2
 
-apt install -y -t testing nvidia-cuda-toolkit nvidia-cuda-dev >> /var/log/$LOGNAME.auto-update.txt 2>&1
+apt install -y -t testing nvidia-cuda-toolkit nvidia-cuda-dev >> /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "SI VOUS UTILISEZ SECUREBOOT, VEUILLEZ RELANNCER LA PROCEDURE !
 

--- a/extra/update-firmware.sh
+++ b/extra/update-firmware.sh
@@ -14,7 +14,7 @@ echo "Mise à jour des linux-firmware vers la dernière version git
 
 echo "installation des dépendances...
 "; sleep 2
-apt get install wget tar gzip > /var/log/$LOGNAME.auto-update.txt 2>&1
+apt get install wget tar gzip > /var/log/"$LOGNAME".auto-update.txt 2>&1
 
 echo "Téléchargement en cours...
 "; sleep 2

--- a/postinstall-debian-gui
+++ b/postinstall-debian-gui
@@ -2,11 +2,11 @@
 
 function main() {
 
-if [ $DESKTOP_SESSION == "plasma" ]; then
+if [ "$DESKTOP_SESSION" == "plasma" ]; then
   password=$( kdialog --password "Entrez votre mot de passe SUDO" )
-elif  [ $DESKTOP_SESSION == "plasmawayland" ]; then
+elif  [ "$DESKTOP_SESSION" == "plasmawayland" ]; then
   password=$( kdialog --password "Entrez votre mot de passe SUDO" )
-elif  [ $DESKTOP_SESSION == "gnome" ]; then
+elif  [ "$DESKTOP_SESSION" == "gnome" ]; then
   password=$( zenity --password --text="Entrez votre mot de passe SUDO" )
 elif [ -f /usr/bin/zenity ]; then
   password=$( zenity --password --text="Entrez votre mot de passe SUDO" )
@@ -14,16 +14,16 @@ fi
 
 #password=$(echo $pwd)
 
-chkroot=$(echo $password | sudo -S whoami)
+chkroot=$(echo "$password" | sudo -S whoami)
 if [ "$password" = "" ]; then
 main
 exit
 elif [ "$chkroot" != "root" ]; then
-  if [ $DESKTOP_SESSION == "plasma" ]; then
+  if [ "$DESKTOP_SESSION" == "plasma" ]; then
     kdialog --error "Mauvais mot de passe"
-  elif  [ $DESKTOP_SESSION == "plasmawayland" ]; then
+  elif  [ "$DESKTOP_SESSION" == "plasmawayland" ]; then
     kdialog --error "Mauvais mot de passe"
-  elif  [ $DESKTOP_SESSION == "gnome" ]; then
+  elif  [ "$DESKTOP_SESSION" == "gnome" ]; then
     zenity --error --text="Mauvais mot de passe"
   elif [ -f /usr/bin/zenity ]; then
     zenity --error --text="Mauvais mot de passe"
@@ -36,17 +36,17 @@ chmod +x extra/*.sh
 chmod +x SECUREBOOT/*.sh
 
 if [ -f /usr/bin/zenity ]; then
-(echo $password | sudo -S apt -y install yad bash-completion) | zenity --progress --pulsate --title="Préparation de YAD" --text="Installation de YAD" --auto-close
+(echo "$password" | sudo -S apt -y install yad bash-completion) | zenity --progress --pulsate --title="Préparation de YAD" --text="Installation de YAD" --auto-close
 elif [ -f /usr/bin/kdialog ]; then
-echo $password | sudo -S apt install -y zenity
-(echo $password | sudo -S apt -y install yad bash-completion pkexec) | zenity --progress --pulsate --title="Préparation de YAD" --text="Installation de YAD" --auto-close
+echo "$password" | sudo -S apt install -y zenity
+(echo "$password" | sudo -S apt -y install yad bash-completion pkexec) | zenity --progress --pulsate --title="Préparation de YAD" --text="Installation de YAD" --auto-close
 fi
 
-(echo $password | sudo -S apt-add-repository -y contrib && \
-echo $password | sudo -S apt-add-repository -y non-free && \
-echo $password | sudo -S dpkg --add-architecture i386) | yad --progress --pulsate --title "Préparation de système" --progress-text="installation des dépôts additionnels" --width 500 --height 100 --no-buttons --auto-close
+(echo "$password" | sudo -S apt-add-repository -y contrib && \
+echo "$password" | sudo -S apt-add-repository -y non-free && \
+echo "$password" | sudo -S dpkg --add-architecture i386) | yad --progress --pulsate --title "Préparation de système" --progress-text="installation des dépôts additionnels" --width 500 --height 100 --no-buttons --auto-close
 
-echo $password | sudo -S bash -e ./source/menu-gui.sh
+echo "$password" | sudo -S bash -e ./source/menu-gui.sh
 }
 
 main

--- a/source/menu-gui.sh
+++ b/source/menu-gui.sh
@@ -6,7 +6,7 @@ logo="./source/logo.png"
 
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 #
-#                   FONCIOTNS POUR LANCER LES INSTALLATIONS ET LES CHARGEMENTS
+#                   FONCTIONS POUR LANCER LES INSTALLATIONS ET LES CHARGEMENTS
 #
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -32,25 +32,25 @@ counter=0
 $data_loc | while read -r line ;
     do
     echo "# ${line}"
-    max_line=$(wc -l $data_loc | cut -d " " -f 1)
+    max_line=$(wc -l "$data_loc" | cut -d " " -f 1)
     max_line2=$(echo "$max_line / 2" | bc -l)
     one_line_percent=$(echo "scale=4; 100 / $max_line2" | bc -l)
     counter=$(echo "$counter + $one_line_percent" | bc -l)
-    counter=$(echo $counter | cut -d "." -f 1)
-    echo $counter ;
+    counter=$(echo "$counter" | cut -d "." -f 1)
+    echo "$counter" ;
         if [ "${line}" = "Job done" ]; then
         counter="100"
-        echo $counter
+        echo "$counter"
         sleep 5
         yad --window-icon="$logo" --width 300 --height 170 --title="FINI" --text-align="center" --text="Installation terminée" --button="OK:bash -c menu"
         fi
     done | yad --progress --percentage=$counter --title "installation de $app_name" --progress-text="installation en cours " --width 500 --height 200 --no-buttons --enable-log --log-expanded
 }
 
-function ferme_yad () { PidYad=$(pgrep yad); kill $PidYad;}
+function ferme_yad () { PidYad=$(pgrep yad); kill "$PidYad";}
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 #
-#                   FONCIOTNS POUR BOUTTONS DU MENU nvidia
+#                   FONCTIONS POUR BOUTTONS DU MENU nvidia
 #
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -74,7 +74,7 @@ function nvidia_secureboot () {
 }
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 #
-#                   FONCIOTNS POUR BOUTTONS DU MENU nvidia2
+#                   FONCTIONS POUR BOUTTONS DU MENU nvidia2
 #
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -95,7 +95,7 @@ function nvidia_test () {
 }
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 #
-#                   FONCIOTNS POUR BOUTTONS DU MENU amd
+#                   FONCTIONS POUR BOUTTONS DU MENU amd
 #
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -117,7 +117,7 @@ function amd_rocm () {
 }
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 #
-#                   FONCIOTNS POUR BOUTTONS DU MENU UTILITAIRES
+#                   FONCTIONS POUR BOUTTONS DU MENU UTILITAIRES
 #
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 function deb_get () {
@@ -168,7 +168,7 @@ function sid () {
 
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 #
-#                   SOUS MENU POUR ACCEDER A L'EXECUTION DES SCTIPTS
+#                   SOUS MENU POUR ACCEDER A L'EXECUTION DES SCRIPTS
 #
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 function secureboot () {
@@ -176,13 +176,13 @@ if [[ -f /usr/bin/konsole ]] ; then
     ferme_yad
     app_name="INSTALLATION DE SECUREBOOT"
     var1="bash -c $localdir/SECUREBOOT/install-sb-gui.sh"
-    konsole -- -e $var1
+    konsole -- -e "$var1"
     menu
 elif [[ -f /usr/bin/gnome-terminal ]] ; then
     ferme_yad
     app_name="INSTALLATION DE SECUREBOOT"
     var1="bash -c $localdir/SECUREBOOT/install-sb-gui.sh"
-    gnome-terminal -x $var1
+    gnome-terminal -x "$var1"
     menu
 else
 yad --window-icon="$logo" --width 300 --height 170 --title="Désolé..." --text-align="center" --text="La GUI ne supporte que KDE. Utilisez la version TUI." --button="OK:bash -c menu"
@@ -194,22 +194,21 @@ logo
 ferme_yad
 COM_STABLE="Installer driver Nvidia Stable (Recommandé)"
 COM_AUTRE="Autres drivers Nvidia (Pour utilisateurs Expérimentés !!)"
-COM_SECUREBOOT="Configurer Secureboot pour Nvidia"
+# COM_SECUREBOOT="Configurer Secureboot pour Nvidia"
 COM_REMOVE="Supprimer driver Nvidia"
 nvidia=$(yad --window-icon="$logo" --title="Gestionnaire nvidia" --width 500 --height 170 --text-align="center" --button="Retour:bash -c menu" --button="OK:0" --button="Cancel:1" \
  --form \
  --field "Stable ! ! $COM_STABLE:fbtn" "bash -c nvidia_stable" \
  --field "Autre ! ! $COM_AUTRE:fbtn" "bash -c nvidia_autre" \
- #--field "Secureboot ! ! $COM_SECUREBOOT:fbtn" "bash -c nvidia_secureboot" \
  --field "Remove ! ! $COM_REMOVE:fbtn" "bash -c nvidia_remove"\
-)
+) #--field "Secureboot ! ! $COM_SECUREBOOT:fbtn" "bash -c nvidia_secureboot" \
 }
 
 function nvidia2 () {
 logo
 ferme_yad
-COM_EXPERIMENTAL="Installer driver Nvidia Experimental (Necessite l'activation de Sid pin 10)"
-COM_CUDA="Installer driver depuis le depot Nvidia Cuda"
+COM_EXPERIMENTAL="Installer driver Nvidia Experimental (Nécessite l'activation de Sid pin 10)"
+COM_CUDA="Installer driver depuis le dépôt Nvidia Cuda"
 COM_TESTING="Installer driver Nvidia de Testing en pin 10 (Pour Debian Stable)"
 nvidia2=$(yad --window-icon="$logo" --title="Gestionnaire nvidia" --width 500 --height 170 --text-align="center" --button="Retour:bash -c nvidia" --button="OK:0" --button="Cancel:1" \
  --form \
@@ -259,7 +258,7 @@ utilitaire=$(yad --window-icon="$logo" --title="Gestionnaire des app utilitaires
 }
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 #
-#                   FONCIOTNS POUR MENU PRINCIPALE
+#                   FONCTIONS POUR MENU PRINCIPAL
 #
 #--------------------------------------------------------------------------------------------------------------------------------------------------
 function menu() {
@@ -298,14 +297,14 @@ ferme_yad
 fi
 count=1
 localdir=$(pwd)
-echo $localdir
+echo "$localdir"
 export localdir
 logo
 CG=$(yad --window-icon="$logo" --title="POSTINSTALL FOR DEBIAN" --width 500 --height 140 --text-align="center" --no-buttons \
  --form \
- --field "Configurer SECUREBOOT:fbtn" "bash -c secureboot" \
- --field "Gesiton des pilotes NVIDIA:fbtn" "bash -c nvidia" \
- --field "Gesiton des pilotes AMD:fbtn" "bash -c amd" \
+ --field "Configurer le SECUREBOOT:fbtn" "bash -c secureboot" \
+ --field "Gestion des pilotes NVIDIA:fbtn" "bash -c nvidia" \
+ --field "Gestion des pilotes AMD:fbtn" "bash -c amd" \
  --field "Applications et Utilitaires:fbtn" "bash -c utilitaire"\
 )
 }

--- a/source/scripts-tui.sh
+++ b/source/scripts-tui.sh
@@ -84,8 +84,8 @@ function add-ppa-debian() {
 clear
 echo "------------------------------------------------------
 "
-read -p 'Saisir le nom du ppa au format "ppa:nom/repository" : ' $1
-bash ./data/add-ppa-debian.sh $1
+read -p 'Saisir le nom du ppa au format "ppa:nom/repository" : ' "$1"
+bash ./data/add-ppa-debian.sh "$1"
 sleep 2
 tools1
 }


### PR DESCRIPTION
Quelques questions en suspend :

1. Les problèmes des `cd <dir>`, sans traiter les erreurs
Donc plutôt `cd <dir> || exit` 
OU une fonction pour bien quitter le programme si les change dir échouent !

2. Dans `secureboot.sh`
**MODULES_DIR** et **KBUILD_DIR** n'ont pas l'air d'être utilisés... 
A voir